### PR TITLE
Disallow addresses outside of NL to buy forwardedl istings

### DIFF
--- a/Model/ListingsApi.php
+++ b/Model/ListingsApi.php
@@ -24,7 +24,7 @@ class ListingsApi implements ListingsApiInterface
         $listings = $this->apiService->getListingBySku($sku);
 
         return array_filter($listings, function (array $listing) {
-            return mb_strtolower($listing['status']) === 'available' && $listing['matched'] === false;
+            return mb_strtolower($listing['status']) === 'available';
         });
     }
 
@@ -43,7 +43,7 @@ class ListingsApi implements ListingsApiInterface
         }
 
         return array_filter($listings, function (array $listing) {
-            return mb_strtolower($listing['status']) === 'available' && $listing['matched'] === false;
+            return mb_strtolower($listing['status']) === 'available';
         });
     }
 }

--- a/Observer/HandleCartAddBefore.php
+++ b/Observer/HandleCartAddBefore.php
@@ -27,6 +27,17 @@ class HandleCartAddBefore implements ObserverInterface
         $itGoesForward = $this->request->getParam('it_goes_forward');
 
         if ($itGoesForward) {
+            //TODO: Check with VPN if it correctly identifies the country adn throws an error
+            // TODO: Inspect how IPs change in the error log - var/log/exception.log
+            $objectManager = ObjectManager::getInstance();
+            $remoteAddress = $objectManager->get(RemoteAddress::class);
+            $ip = $remoteAddress->getRemoteAddress();
+            $ip_data = @json_decode(file_get_contents("http://www.geoplugin.net/json.gp?ip=".$ip));
+
+            //Test with VPN
+            if($ip_data && $ip_data->geoplugin_countryCode != "NL"){
+                throw new \Exception("You are not allowed to add this product to the cart: " . $ip_data->geoplugin_countryCode . " With IP: " . $ip);
+            }
             $product = $observer->getProduct();
             $product->addCustomOption('it_goes_forward', $itGoesForward);
         }


### PR DESCRIPTION
Good to be checked:

1. Is the IP address correctly read by the system and are clients filtered.
 - An exception is thrown if a forwarded item is added to the cart by a user outside of NL
 - Use a VPN to test it for outside the NL